### PR TITLE
[Minestom] fixed Plasmo breaking when changing world

### DIFF
--- a/minestom/src/main/kotlin/su/plo/slib/minestom/MinestomServerLib.kt
+++ b/minestom/src/main/kotlin/su/plo/slib/minestom/MinestomServerLib.kt
@@ -144,6 +144,7 @@ class MinestomServerLib(
     }
 
     private val playerJoinListener: Consumer<PlayerSpawnEvent> = Consumer { event ->
+        if (!event.isFirstSpawn) return@Consumer
         val player = getPlayerByInstance(event.player) as MinestomServerPlayer
         McPlayerJoinEvent.invoker.onPlayerJoin(player)
 


### PR DESCRIPTION
In Minestom, PlayerSpawnEvent is called every time it spawns into the world. Because of this, when the world changes, playerJoinListener is called again and Plasmo stops working.